### PR TITLE
Adding task definition example for AWS Fargate

### DIFF
--- a/aws-fargate-ecs/fargate-task-definition-example.json
+++ b/aws-fargate-ecs/fargate-task-definition-example.json
@@ -1,0 +1,41 @@
+{
+        "family": "wavefront-task-def",
+        "networkMode": "awsvpc",
+        "containerDefinitions": [
+            {
+                "name": "tomcat-example",
+                "image": "tomcat:latest",
+                "essential": true,
+				"portMappings": [
+					{
+					  "hostPort": 8080,
+					  "protocol": "tcp",
+					  "containerPort": 8080
+					}
+				]
+            }, 
+			{
+                "name": "fargate-metrics-collector",
+                "image": "wavefronthq/wavefront-fargate-collector:0.9.0",
+                "essential": true,
+                "environment": [],
+				"portMappings": [
+					{
+					  "hostPort": 8000,
+					  "protocol": "tcp",
+					  "containerPort": 8000
+					}
+				],
+				"command": [
+					"-port=8000",
+					"-storage_driver=wavefront",
+					"-storage_driver_options=storage_driver_wf_proxy_host=YOUR_PROXY_ADDRESS storage_driver_wf_metric_prefix=aws.fargate.ecs."
+				]
+			}
+        ],
+        "requiresCompatibilities": [
+            "FARGATE"
+        ],
+        "cpu": "256",
+        "memory": "512"
+}

--- a/aws-fargate-ecs/fargate-task-definition-example.json
+++ b/aws-fargate-ecs/fargate-task-definition-example.json
@@ -16,7 +16,7 @@
             }, 
 			{
                 "name": "fargate-metrics-collector",
-                "image": "wavefronthq/wavefront-fargate-collector:0.9.0",
+                "image": "wavefronthq/wavefront-fargate-collector:latest",
                 "essential": true,
                 "environment": [],
 				"portMappings": [


### PR DESCRIPTION
It includes deploying a tomcat container with wavefront fargate collector to collect the metrics.

**Note:** Wavefront faragte collector needs to be uploaded to docker hub with the latest tag and the same tag will be updated here.