### PR TITLE
To avoid deprecated function call to requests.post()

### DIFF
--- a/aws/scripts/access_key_check.py
+++ b/aws/scripts/access_key_check.py
@@ -7,7 +7,7 @@ import os
 import datetime
 import json
 import boto3
-from botocore.vendored import requests
+import requests
 
 
 # The AWS_PROFILES must also exist in your ~/.aws/credentials file


### PR DESCRIPTION
To avoid deprecated warning for `post()` function call from `botocore.vendored.requests`. This API will be removed in the future.

This is compatible with both Python 2.7 & 3.x versions.