### PR TITLE
fix(INT-921): update Telegraf version to 1.17.2

### DIFF
--- a/aws-ecs/Dockerfile
+++ b/aws-ecs/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used as it's own deployment to collect metrics
 
-FROM wavefronthq/telegraf:latest
+FROM telegraf:1.17.2
 
 ENV ECS_CONTAINER_METADATA_ENDPOINT=""
 

--- a/aws-ecs/telegraf.conf
+++ b/aws-ecs/telegraf.conf
@@ -54,7 +54,7 @@
 
   ## ecs labels to include and exclude as tags.  Globs accepted.
   ## Note that an empty array for both will include all labels as tags
-  ecs_label_include = [ "com.amazonaws.ecs.*" ]
+  ecs_label_include = []
   ecs_label_exclude = []
 
 

--- a/aws-ecs/telegraf.conf
+++ b/aws-ecs/telegraf.conf
@@ -55,7 +55,7 @@
   ## ecs labels to include and exclude as tags.  Globs accepted.
   ## Note that an empty array for both will include all labels as tags
   ecs_label_include = []
-  ecs_label_exclude = []
+  ecs_label_exclude = [ "com.amazonaws.ecs.*" ]
 
 
 # Configuration for Wavefront proxy to send metrics to


### PR DESCRIPTION
**PR description:**
This PR is regarding the replacement of cadvisor with the Telegraf agent to scrape the metrics from AWS ECS service.

Please find below the image available in the AWS ECR for testing purpose(The docker image is yet to be made publicly available).
358321641467.dkr.ecr.us-west-2.amazonaws.com/svinothini-wavefront:telegraf-ecs-test

For example,
"containerDefinitions": [
```
{
    "name": "aws-ecs-ec2-wavefront",
    "image": "358321641467.dkr.ecr.us-west-2.amazonaws.com/svinothini-wavefront:tele-exclude-labels",
    "memory": "150",
}
```