### PR TITLE
Adding Reference to sample cassandra-preprocessor-configMap & wf-proxy deployment with preprocessor rules

### DIFF
--- a/cassandra/cassandra-preprocessor-rules-configmap.yaml
+++ b/cassandra/cassandra-preprocessor-rules-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wavefront-proxy-preprocessor
+  namespace: default
+data:
+  rules.yaml: |
+     '2878':
+       - rule    : cassandra-metrics-allow
+         action  : allow
+         scope   : metricName
+         match   : "cassandra.(mcac|stargate|jvm).*"

--- a/cassandra/wavefront-with-preprocessor-rules.yaml
+++ b/cassandra/wavefront-with-preprocessor-rules.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: wavefront-proxy
-          image: projects.registry.vmware.com/tanzu_observability/proxy:11.0
+          image: projects.registry.vmware.com/tanzu_observability/proxy:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: WAVEFRONT_URL

--- a/cassandra/wavefront-with-preprocessor-rules.yaml
+++ b/cassandra/wavefront-with-preprocessor-rules.yaml
@@ -1,0 +1,71 @@
+# Need to change YOUR_CLUSTER and YOUR_API_TOKEN accordingly
+
+apiVersion: apps/v1
+# Kubernetes versions after 1.9.0 should use apps/v1
+# Kubernetes version 1.8.x should use apps/v1beta2
+# Kubernetes versions before 1.8.0 should use apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: wavefront-proxy
+    name: wavefront-proxy
+  name: wavefront-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wavefront-proxy
+  template:
+    metadata:
+      labels:
+        app: wavefront-proxy
+    spec:
+      containers:
+        - name: wavefront-proxy
+          image: projects.registry.vmware.com/tanzu_observability/proxy:11.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WAVEFRONT_URL
+              value: https://<YOUR_CLUSTER_NAME>.wavefront.com/api/
+            - name: WAVEFRONT_TOKEN
+              value: <WAVEFRONT_TOKEN>
+            - name: WAVEFRONT_PROXY_ARGS
+              value: --preprocessorConfigFile /etc/wavefront/wavefront-proxy/rules.yaml
+          ports:
+            - containerPort: 2878
+              protocol: TCP
+          # Uncomment the below lines to consume Zipkin/Istio traces
+          #- containerPort: 9411
+          #  protocol: TCP
+          securityContext:
+            privileged: false
+          # Mount the preprocessor rules
+          volumeMounts:
+           - name: preprocessor
+             mountPath: /etc/wavefront/wavefront-proxy/rules.yaml
+             subPath: rules.yaml
+      volumes:
+        - name: preprocessor
+          configMap:
+            name: wavefront-proxy-preprocessor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wavefront-proxy
+  labels:
+    app: wavefront-proxy
+  namespace: default
+spec:
+  ports:
+    - name: wavefront
+      port: 2878
+      protocol: TCP
+  # Uncomment the below lines to consume Zipkin/Istio traces
+  #- name: http
+  #  port: 9411
+  #  targetPort: 9411
+  #  protocol: TCP
+  selector:
+    app: wavefront-proxy


### PR DESCRIPTION
This change list contains changes to add sample reference file for cassandra preprocessor ConfigMaps and wavefront proxy configuration required for preprocessor rules.